### PR TITLE
add isLibrary support to buildTools

### DIFF
--- a/buildTools/build.js
+++ b/buildTools/build.js
@@ -35,6 +35,10 @@ function addMeta(config) {
         }
     }
 
+    if(config.isLibrary) {
+        meta += '\n * @isLibrary true';
+    }
+
     meta += '\n */\n';
 
     return {


### PR DESCRIPTION
Adds isLibrary support in buildTools, so that you can do 
```js
import fs from 'fs';

const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));

export default {
  // ...
  isLibrary: true,
  // ...
};
```
in `GL.config.js`