### PR TITLE
Add gamemode types/icons in plugins

### DIFF
--- a/src/content/core/ui/circleImage.ts
+++ b/src/content/core/ui/circleImage.ts
@@ -1,0 +1,30 @@
+const size = 30;
+
+export default async function circleImage(url: string) {
+    let img = await new Promise<HTMLImageElement>((resolve, reject) => {
+        let i = new Image();
+        i.onload = () => resolve(i);
+        i.onerror = reject;
+        i.src = url;
+    });
+
+    let cropSize = Math.min(img.width, img.height);
+    let sx = (img.width - cropSize) / 2;
+    let sy = (img.height - cropSize) / 2;
+
+    let canvas = document.createElement('canvas');
+    let ctx = canvas.getContext('2d');
+    canvas.width = size;
+    canvas.height = size;
+	let radius = size / 2;
+
+    ctx.beginPath();
+    ctx.arc(radius, radius, radius, 0, Math.PI * 2);
+    ctx.closePath();
+    ctx.clip();
+
+    ctx.drawImage(img, sx, sy, cropSize, cropSize, 0, 0, size, size);
+
+    let blob = await new Promise<Blob>(resolve => canvas.toBlob(resolve, 'image/png'));
+    return URL.createObjectURL(blob);
+}

--- a/src/content/core/ui/ui.ts
+++ b/src/content/core/ui/ui.ts
@@ -4,11 +4,43 @@ import { addPluginButtons } from './addPluginButtons';
 import styles from "../../css/styles.scss";
 import { domLoaded } from '$content/utils';
 import Rewriter from '../rewriter';
+import type { Experiences } from '$types/fetch';
+import net from '../net/net';
+import circleImage from './circleImage';
+
+
+export interface ParsedGamemode {
+    name: string;
+    id: string;
+    image: string;
+}
+
+async function parseGamemodes(experiences: Experiences): Promise<ParsedGamemode[]> {
+    let gamemodes = experiences.flatMap(exp => exp.items);
+
+    return Promise.all(
+        gamemodes.map(async gm => ({
+            name: gm.name,
+            id: net.gamemodeFromUrl(gm.imageUrl),
+            image: await circleImage(gm.imageUrl)
+        }))
+    );
+}
 
 export default class UI {
     static React: typeof React;
     static ReactDOM: typeof ReactDOM;
     static styles: Map<string, HTMLStyleElement[]> = new Map();
+    static gamemodesRes = fetch("/api/experiences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            "mode": "liveGame",
+            "forceUpgradedExperiences": false
+        })
+    })
+        .then<Experiences>(res => res.json())
+        .then(parseGamemodes);
 
     static init() {
         Rewriter.exposeObjectBefore(true, "React", ".useDebugValue=", (react) => {

--- a/src/content/ui/components/Card.svelte
+++ b/src/content/ui/components/Card.svelte
@@ -12,6 +12,7 @@
         toggle?: Snippet;
         author?: Snippet;
         description?: Snippet;
+        gamemodes?: Snippet;
         buttons?: Snippet;
         border?: string;
         hasDrag?: boolean;
@@ -27,6 +28,7 @@
         toggle,
         author,
         description,
+        gamemodes,
         buttons,
         border,
         hasDrag = true
@@ -54,8 +56,15 @@ h-full relative bg-white min-h-[150px] rounded-xl preflight flex flex-col p-3">
     <div class="flex-grow text-sm pr-7 overflow-hidden overflow-ellipsis line-clamp-6">
         {@render description?.()}
     </div>
-    <div class="flex flex-row-reverse items-end">
-        {@render buttons?.()}
+    <div class="flex flex-row overflow-hidden">
+        <div class="flex-1 overflow-x-auto whitespace-nowrap">
+            <div class="flex flex-row gap-1 inline-block min-w-max">
+                {@render gamemodes?.()}
+            </div>
+        </div>
+        <div class="flex flex-none flex-row-reverse items-end">
+            {@render buttons?.()}
+        </div>
     </div>
     {#if hasDrag}
         <div class="absolute right-3 top-1/2 transform -translate-y-1/2"

--- a/src/content/ui/components/ListItem.svelte
+++ b/src/content/ui/components/ListItem.svelte
@@ -14,6 +14,7 @@
         buttons?: Snippet;
         author?: Snippet;
         description?: Snippet;
+        gamemodes?: Snippet;
         border?: string;
         hasDrag?: boolean;
     }
@@ -29,6 +30,7 @@
         buttons,
         author,
         description,
+        gamemodes,
         border,
         hasDrag = true
     }: Props = $props();
@@ -75,6 +77,9 @@ p-3 h-full bg-white preflight rounded-xl relative">
             </div>
             <div class="flex-grow text-sm pr-7 overflow-hidden overflow-ellipsis">
                 {@render description?.()}
+            </div>
+            <div class="flex flex-row gap-1">
+                {@render gamemodes?.()}
             </div>
         </div>
     {/if}

--- a/src/content/ui/libraries/Library.svelte
+++ b/src/content/ui/libraries/Library.svelte
@@ -57,8 +57,8 @@
     {/snippet}
     {#snippet gamemodes()}
         {#each library?.headers.gamemode as gamemode}
-            {#if Object.keys(modeDescriptions).includes(gamemode.toLowerCase())}
-                <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode]}</div>
+            {#if gamemode.toLowerCase() in modeDescriptions}
+                <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode.toLowerCase()]}</div>
             {:else}
                 {@const parsedGamemode = parsedGamemodes.find(gm => gm.id.toLowerCase() === gamemode.toLowerCase())}
                 <img src={parsedGamemode.image} title={parsedGamemode.name} alt={parsedGamemode.name}>

--- a/src/content/ui/libraries/Library.svelte
+++ b/src/content/ui/libraries/Library.svelte
@@ -10,6 +10,8 @@
     import ListItem from "../components/ListItem.svelte";
     import Storage from "$core/storage.svelte";
     import { showEditor } from "$content/utils";
+    import modeDescriptions from '../modeDescriptions';
+    import type { ParsedGamemode } from '$content/core/ui/ui';
 
     function deleteLib() {
         let conf = confirm(`Are you sure you want to delete ${library.headers.name}?`);
@@ -22,6 +24,7 @@
         startDrag: () => void;
         dragDisabled: boolean;
         library: Lib;
+        gamemodes: ParsedGamemode[];
         dragAllowed: boolean;
     }
 
@@ -29,6 +32,7 @@
         startDrag,
         dragDisabled,
         library,
+        gamemodes: parsedGamemodes,
         dragAllowed
     }: Props = $props();
 
@@ -50,6 +54,16 @@
     {/snippet}
     {#snippet description()}
         {library?.headers.description}
+    {/snippet}
+    {#snippet gamemodes()}
+        {#each library?.headers.gamemode as gamemode}
+            {#if Object.keys(modeDescriptions).includes(gamemode.toLowerCase())}
+                <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode]}</div>
+            {:else}
+                {@const parsedGamemode = parsedGamemodes.find(gm => gm.id.toLowerCase() === gamemode.toLowerCase())}
+                <img src={parsedGamemode.image} title={parsedGamemode.name} alt={parsedGamemode.name}>
+            {/if}
+        {/each}
     {/snippet}
     {#snippet buttons()}
         <button onclick={deleteLib}>

--- a/src/content/ui/libraries/LibraryCardsList.svelte
+++ b/src/content/ui/libraries/LibraryCardsList.svelte
@@ -13,6 +13,7 @@
     import Import from 'svelte-material-icons/Import.svelte';
     import ChevronDown from 'svelte-material-icons/ChevronDown.svelte';
     import ViewControl from "../components/ViewControl.svelte";
+    import UI from '$content/core/ui/ui';
     
     let { onDrop }: { onDrop: (callback: (text: string) => void) => void } = $props();
 
@@ -89,16 +90,21 @@
     {#if LibManager.libs.length === 0}
         <h2 class="text-xl">No libraries installed!</h2>
     {/if}
-    <div class="overflow-y-auto grid gap-4 view-{Storage.settings.menuView} pb-1 flex-grow"
-    use:dndzone={{ items, flipDurationMs, dragDisabled, dropTargetStyle: {} }}
-    onconsider={handleDndConsider} onfinalize={handleDndFinalize}>
-        {#key searchValue}
-            {#each items as item (item.id)}
-                {@const library = LibManager.getLib(item.id)}
-                <div animate:flip={{ duration: flipDurationMs }}>
-                    <Library {library} {startDrag} {dragDisabled} dragAllowed={searchValue == ''} />
-                </div>
-            {/each}
-        {/key}
-    </div>
+    {#await UI.gamemodesRes then gamemodes}
+        <div
+            class="overflow-y-auto grid gap-4 view-{Storage.settings.menuView} pb-1 flex-grow"
+            use:dndzone={{ items, flipDurationMs, dragDisabled, dropTargetStyle: {} }}
+            onconsider={handleDndConsider}
+            onfinalize={handleDndFinalize}
+        >
+            {#key searchValue}
+                {#each items as item (item.id)}
+                    {@const library = LibManager.getLib(item.id)}
+                    <div animate:flip={{ duration: flipDurationMs }}>
+                        <Library {library} {gamemodes} {startDrag} {dragDisabled} dragAllowed={searchValue == ''} />
+                    </div>
+                {/each}
+            {/key}
+        </div>
+    {/await}
 </div>

--- a/src/content/ui/modeDescriptions.ts
+++ b/src/content/ui/modeDescriptions.ts
@@ -1,0 +1,8 @@
+export default {
+    "*": "All Modes",
+    "2d": "2D Modes",
+    "1d": "1D Modes",
+    "official": "Official Modes",
+    "official-2d": "Official 2D Modes",
+    "creative": "Creative Modes"
+};

--- a/src/content/ui/plugins/Plugin.svelte
+++ b/src/content/ui/plugins/Plugin.svelte
@@ -96,8 +96,8 @@
     {/snippet}
     {#snippet gamemodes()}
         {#each plugin?.headers.gamemode as gamemode}
-            {#if Object.keys(modeDescriptions).includes(gamemode.toLowerCase())}
-                <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode]}</div>
+            {#if gamemode.toLowerCase() in modeDescriptions}
+                <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode.toLowerCase()]}</div>
             {:else}
                 {@const parsedGamemode = parsedGamemodes.find(gm => gm.id.toLowerCase() === gamemode.toLowerCase())}
                 <img src={parsedGamemode.image} title={parsedGamemode.name} alt={parsedGamemode.name}>

--- a/src/content/ui/plugins/Plugin.svelte
+++ b/src/content/ui/plugins/Plugin.svelte
@@ -95,7 +95,7 @@
         {plugin?.headers.description}
     {/snippet}
     {#snippet gamemodes()}
-        {#each plugin.headers.gamemode as gamemode}
+        {#each plugin?.headers.gamemode as gamemode}
             {#if Object.keys(modeDescriptions).includes(gamemode.toLowerCase())}
                 <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode]}</div>
             {:else}

--- a/src/content/ui/plugins/Plugin.svelte
+++ b/src/content/ui/plugins/Plugin.svelte
@@ -17,11 +17,14 @@
     import ScriptTextOutline from 'svelte-material-icons/ScriptTextOutline.svelte';
     import AlertCircleOutline from 'svelte-material-icons/AlertCircleOutline.svelte';
     import { showEditor } from "$content/utils";
+    import type { ParsedGamemode } from '$content/core/ui/ui';
+    import modeDescriptions from '../modeDescriptions';
 
     interface Props {
         startDrag: () => void;
         dragDisabled: boolean;
         plugin: Plugin;
+        gamemodes: ParsedGamemode[];
         dragAllowed: boolean;
     }
 
@@ -29,6 +32,7 @@
         startDrag,
         dragDisabled,
         plugin,
+        gamemodes: parsedGamemodes,
         dragAllowed
     }: Props = $props();
 
@@ -58,6 +62,8 @@
 
     let component = $derived(Storage.settings.menuView === 'grid' ? Card : ListItem);
     const SvelteComponent = $derived(component);
+
+    
 </script>
 
 {#if libInfoOpen}
@@ -87,6 +93,16 @@
     {/snippet}
     {#snippet description()}
         {plugin?.headers.description}
+    {/snippet}
+    {#snippet gamemodes()}
+        {#each plugin.headers.gamemode as gamemode}
+            {#if Object.keys(modeDescriptions).includes(gamemode.toLowerCase())}
+                <div class="bg-gray-400 px-2 bold rounded-full">{modeDescriptions[gamemode]}</div>
+            {:else}
+                {@const parsedGamemode = parsedGamemodes.find(gm => gm.id.toLowerCase() === gamemode.toLowerCase())}
+                <img src={parsedGamemode.image} title={parsedGamemode.name} alt={parsedGamemode.name}>
+            {/if}
+        {/each}
     {/snippet}
     {#snippet buttons()}
         <button onclick={() => deletePlugin(plugin)}>

--- a/src/content/ui/plugins/PluginCardsList.svelte
+++ b/src/content/ui/plugins/PluginCardsList.svelte
@@ -15,8 +15,13 @@
     import PlusBoxOutline from 'svelte-material-icons/PlusBoxOutline.svelte';
     import Import from 'svelte-material-icons/Import.svelte';
     import ChevronDown from 'svelte-material-icons/ChevronDown.svelte';
+    import UI from '$content/core/ui/ui';
 
-    let { onDrop }: { onDrop: (callback: (text: string) => void) => void } = $props();
+    interface Props {
+        onDrop: (callback: (text: string) => void) => void
+    }
+
+    let { onDrop }: Props = $props();
 
     onDrop((text: string) => {
         PluginManager.createPlugin(text);
@@ -121,16 +126,21 @@
             or import or create your own.
         </h2>
     {/if}
-    <div class="overflow-y-auto grid gap-4 pb-1 flex-grow view-{Storage.settings.menuView}"
-    use:dndzone={{ items, flipDurationMs, dragDisabled, dropTargetStyle: {} }}
-    onconsider={handleDndConsider} onfinalize={handleDndFinalize}>
-        {#key searchValue}
-            {#each items as item (item.id)}
-                {@const plugin = PluginManager.getPlugin(item.id)}
-                <div animate:flip={{ duration: flipDurationMs }}>
-                    <Plugin {plugin} {startDrag} {dragDisabled} dragAllowed={searchValue == ""} />
-                </div>
-            {/each}
-        {/key}
-    </div>
+    {#await UI.gamemodesRes then gamemodes}
+        <div
+            class="overflow-y-auto grid gap-4 pb-1 flex-grow view-{Storage.settings.menuView}"
+            use:dndzone={{ items, flipDurationMs, dragDisabled, dropTargetStyle: {} }}
+            onconsider={handleDndConsider}
+            onfinalize={handleDndFinalize}
+        >
+            {#key searchValue}
+                {#each items as item (item.id)}
+                    {@const plugin = PluginManager.getPlugin(item.id)}
+                    <div animate:flip={{ duration: flipDurationMs }}>
+                        <Plugin {plugin} {gamemodes} {startDrag} {dragDisabled} dragAllowed={searchValue == ""} />
+                    </div>
+                {/each}
+            {/key}
+        </div>
+    {/await}
 </div>

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -1,0 +1,19 @@
+export interface Gamemode {
+    _id: string;
+    name: string;
+    tagline: string;
+    imageUrl: string;
+    source: string;
+    pageId: string;
+    mapId: string;
+    isPremiumExperience: boolean;
+    tag: string;
+}
+
+interface Category {
+    _id: string;
+    name: string;
+    items: Gamemode[];
+}
+
+export type Experiences = Category[];


### PR DESCRIPTION
<img width="415" height="166" alt="image" src="https://github.com/user-attachments/assets/54df0023-52e5-4f31-88cf-3d0ccec24ab9" />

When Gimkit loads, `/api/experiences` is asynchronously fetched (gives names/image paths of gamemodes), then all the gamemode images are asynchronously fetched and turned into 30x30 circular images. These image paths obviously have the same ID placement that Gimloader detects the gamemode by.

If this looks good:
- Should these types/icons be buttons where you can toggle what gamemodes or types the plugin runs on? That would be really helpful for something like AutoSplitter
- Should the gamemode name be added to net API?
- We shouldn't replace the ID with the name, because experiences are asynchronously fetched... unless it would be cleaner to make them blocking
- The README image should be updated