### PR TITLE
Allow Changing Settings From the Command Palette

### DIFF
--- a/src/content/core/scripts/scripts.svelte.ts
+++ b/src/content/core/scripts/scripts.svelte.ts
@@ -153,7 +153,7 @@ export class Plugin extends BaseScript {
     enablePromise: Promise<void> | null = null;
     errored = $state(false);
     settingsDescription?: PluginSettingsDescription;
-    cleanupConfigureCommand?: () => void = undefined;
+    cleanupConfigureCommand?: () => void;
 
     constructor(script: string, enabled = true) {
         super(script);


### PR DESCRIPTION
~~2 things: I couldn't figure out how to only add the command for commands that have settings, and there also seems to be an upstream bug where hitting enter causes `Commands.onSelect` to be run twice when selecting options with the enter key.~~

EDIT: Both of these have been fixed.